### PR TITLE
Support entities

### DIFF
--- a/.github/workflows/verification.yml
+++ b/.github/workflows/verification.yml
@@ -17,8 +17,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        core-branch: [main]  # Adjust branches/tags as needed
-        gradle-plugin-branch: [main]
+        core-branch: [entities]  # Adjust branches/tags as needed
+        gradle-plugin-branch: [entities]
     name: Compatibility verification
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/verification.yml
+++ b/.github/workflows/verification.yml
@@ -17,8 +17,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        core-branch: [entities]  # Adjust branches/tags as needed
-        gradle-plugin-branch: [entities]
+        core-branch: [main]  # Adjust branches/tags as needed
+        gradle-plugin-branch: [main]
     name: Compatibility verification
     steps:
       - uses: actions/checkout@v4

--- a/src/main/java/org/ois/idea/ui/OisToolWindow.java
+++ b/src/main/java/org/ois/idea/ui/OisToolWindow.java
@@ -11,6 +11,7 @@ import org.jetbrains.annotations.NotNull;
 import org.ois.idea.actions.ViewSelectorAction;
 import org.ois.idea.events.ProjectViewEvents;
 import org.ois.idea.project.OisProject;
+import org.ois.idea.ui.views.entities.EntitiesView;
 import org.ois.idea.ui.views.project.CreateProjectView;
 import org.ois.idea.ui.views.project.ProjectConfigView;
 
@@ -63,7 +64,7 @@ public class OisToolWindow extends SimpleToolWindowPanel implements Disposable {
         views = Map.of(
                 View.Create, CreateProjectView.getInstance(project),
                 View.Project, ProjectConfigView.getInstance(project),
-                View.Entities, getDefaultView(View.Entities),
+                View.Entities, EntitiesView.getInstance(project),
                 View.Inspector, getDefaultView(View.Inspector)
         );
 

--- a/src/main/java/org/ois/idea/ui/views/entities/EntitiesView.java
+++ b/src/main/java/org/ois/idea/ui/views/entities/EntitiesView.java
@@ -1,0 +1,145 @@
+package org.ois.idea.ui.views.entities;
+
+import com.intellij.openapi.fileEditor.FileEditorManager;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.Messages;
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.ui.treeStructure.SimpleTree;
+import com.intellij.ui.components.JBScrollPane;
+import org.jetbrains.annotations.NotNull;
+import org.ois.idea.ui.views.OisToolView;
+import org.ois.idea.utils.ProjectUtils;
+
+import javax.swing.*;
+import javax.swing.tree.DefaultMutableTreeNode;
+import javax.swing.tree.DefaultTreeModel;
+import javax.swing.tree.TreePath;
+import java.awt.*;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.*;
+import java.util.Objects;
+
+public class EntitiesView extends OisToolView {
+
+    private final String basePath;
+
+    private final JTree directoryTree;
+    private final DefaultTreeModel treeModel;
+    private final DefaultMutableTreeNode rootNode;
+
+    private WatchService watchService;
+    private Thread watchThread;
+
+    public static EntitiesView getInstance(Project project) {
+        return project.getService(EntitiesView.class);
+    }
+
+    public EntitiesView(@NotNull Project project) {
+        super(project);
+
+        this.basePath = ProjectUtils.getProjectBasePath(project).resolve("simulation").resolve("entities").toString();
+
+        setLayout(new BorderLayout());
+
+        JButton addButton = new JButton("Add Entity");
+        addButton.addActionListener(e -> addNewEntity());
+
+        JPanel topPanel = new JPanel(new BorderLayout());
+        topPanel.add(addButton, BorderLayout.CENTER);
+        add(topPanel, BorderLayout.NORTH);
+
+        rootNode = new DefaultMutableTreeNode("Entities");
+        treeModel = new DefaultTreeModel(rootNode);
+        directoryTree = new SimpleTree(treeModel);
+        refreshDirectoryTree();
+
+        directoryTree.addMouseListener(new MouseAdapter() {
+            @Override
+            public void mouseClicked(MouseEvent e) {
+                if (e.getClickCount() == 2) {
+                    TreePath path = directoryTree.getSelectionPath();
+                    if (path != null) {
+                        DefaultMutableTreeNode node = (DefaultMutableTreeNode) path.getLastPathComponent();
+                        openBlueprintFile(node.getUserObject().toString());
+                    }
+                }
+            }
+        });
+
+        add(new JBScrollPane(directoryTree), BorderLayout.CENTER);
+        startDirectoryWatcher();
+    }
+
+    private void refreshDirectoryTree() {
+        rootNode.removeAllChildren();
+        File dir = new File(basePath);
+        if (dir.exists() && dir.isDirectory()) {
+            for (File subDir : Objects.requireNonNull(dir.listFiles(File::isDirectory))) {
+                DefaultMutableTreeNode node = new DefaultMutableTreeNode(subDir.getName());
+                rootNode.add(node);
+            }
+        }
+        treeModel.reload();
+    }
+
+    private void openBlueprintFile(String dirName) {
+        if (dirName == null) return;
+        Path dirPath = Paths.get(basePath, dirName);
+        Path filePath = dirPath.resolve(dirName + ".blueprint.ois");
+
+        if (!Files.exists(filePath)) {
+            Messages.showErrorDialog(project, "Blueprint file not found in '" + dirName + "'. Please verify the file exists.", "File Not Found");
+            return;
+        }
+
+        VirtualFile file = LocalFileSystem.getInstance().refreshAndFindFileByIoFile(filePath.toFile());
+        if (file != null) {
+            FileEditorManager.getInstance(project).openFile(file, true);
+        }
+    }
+
+    private void addNewEntity() {
+        String entityName = Messages.showInputDialog(project, "Enter entity name:", "New Entity", Messages.getQuestionIcon());
+        if (entityName == null || entityName.trim().isEmpty()) return;
+
+        Path entityDir = Paths.get(basePath, entityName);
+        Path entityFile = entityDir.resolve(entityName + ".blueprint.ois");
+
+        try {
+            Files.createDirectories(entityDir);
+            Files.writeString(entityFile, "{}" );
+            LocalFileSystem.getInstance().refreshAndFindFileByIoFile(entityDir.toFile());
+            refreshDirectoryTree();
+        } catch (IOException e) {
+            Messages.showErrorDialog(project, "Failed to create entity: " + e.getMessage(), "Error");
+        }
+    }
+
+    private void startDirectoryWatcher() {
+        try {
+            watchService = FileSystems.getDefault().newWatchService();
+            Paths.get(basePath).register(watchService, StandardWatchEventKinds.ENTRY_CREATE, StandardWatchEventKinds.ENTRY_DELETE, StandardWatchEventKinds.ENTRY_MODIFY);
+            watchThread = new Thread(() -> {
+                while (true) {
+                    try {
+                        WatchKey key = watchService.take();
+                        for (WatchEvent<?> event : key.pollEvents()) {
+                            SwingUtilities.invokeLater(this::refreshDirectoryTree);
+                        }
+                        key.reset();
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        break;
+                    }
+                }
+            });
+            watchThread.start();
+        } catch (IOException e) {
+            Messages.showErrorDialog(project, "Failed to watch directory: " + e.getMessage(), "Error");
+        }
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -36,6 +36,7 @@
         <projectService serviceImplementation="org.ois.idea.ui.OisToolWindow"/>
         <projectService serviceImplementation="org.ois.idea.ui.views.project.CreateProjectView"/>
         <projectService serviceImplementation="org.ois.idea.ui.views.project.ProjectConfigView"/>
+        <projectService serviceImplementation="org.ois.idea.ui.views.entities.EntitiesView"/>
 
     </extensions>
 


### PR DESCRIPTION
- [ ] If this feature effect users, update the [documentation](https://github.com/attiasas/ois-idea-plugin/blob/main/README.md) and the [wiki](https://github.com/attiasas/ois-core/wiki)
- [ ] This feature was validated on all supported platforms
-----

Depends on:
* https://github.com/attiasas/ois-core/pull/9
* https://github.com/attiasas/ois-gradle-plugin/pull/6

# Integrating Entity View

## Overview
This PR introduces a new **Entity View** in the IntelliJ plugin, providing users with an interface to manage and interact with entities in the simulation project. The new view is integrated into the **OIS Tool Window**, allowing users to browse, create, and open entity blueprints within the IDE.

## Key Changes
### **Entities View Implementation (`EntitiesView.java`)**
- Added a new panel `EntitiesView` under `org.ois.idea.ui.views.entities`.
- Displays a tree structure representing entity directories under `simulation/entities`.
- Allows users to **double-click** on an entity to open its corresponding `.blueprint.ois` file in the editor.
- Provides an "Add Entity" button to create a new entity directory and blueprint file.
- Implements a **file system watcher** to update the view when entity files are created, modified, or deleted.

